### PR TITLE
Order coupon category model fields

### DIFF
--- a/app/models/coupon.py
+++ b/app/models/coupon.py
@@ -53,6 +53,10 @@ class CouponCategory(Base):
     __tablename__ = "coupon_categories"
     
     id: Mapped[str] = mapped_column(String(50), primary_key=True)  # "food", "fashion", etc.
+    # === Relationships ===
+    coupons: Mapped[list["Coupon"]] = relationship(
+        "Coupon", back_populates="category", cascade="all, delete-orphan"
+    )
     name_he: Mapped[str] = mapped_column(String(100))  # "🍕 מסעדות ואוכל"
     name_en: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
@@ -78,10 +82,7 @@ class CouponCategory(Base):
         init=False
     )
     
-    # === Relationships ===
-    coupons: Mapped[list["Coupon"]] = relationship(
-        "Coupon", back_populates="category", cascade="all, delete-orphan"
-    )
+    
     
     # Indexes
     __table_args__ = (


### PR DESCRIPTION
Reorder fields in `CouponCategory` model to place non-default fields before default fields, with `coupons` immediately after `id`.

---
<a href="https://cursor.com/background-agent?bcId=bc-ebdf4455-4720-4385-816b-9c0b81fb2601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ebdf4455-4720-4385-816b-9c0b81fb2601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

