### PR TITLE
Fix coupon model dataclass argument order

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,32 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    env:
+      TELEGRAM_BOT_TOKEN: test-token
+      DATABASE_URL: postgresql+asyncpg://user:pass@localhost:5432/testdb
+      SECRET_KEY: test-secret
+      ENVIRONMENT: development
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Run tests
+        run: pytest -q
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,11 +21,14 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Set PYTHONPATH
+        run: echo "PYTHONPATH=$PYTHONPATH:$(pwd)" >> $GITHUB_ENV
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest
+          pip install pytest pytest-asyncio
 
       - name: Run tests
         run: pytest -q

--- a/app/models/coupon.py
+++ b/app/models/coupon.py
@@ -72,12 +72,12 @@ class CouponCategory(Base):
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), 
-        default=lambda: datetime.now(timezone.utc),
+        default_factory=lambda: datetime.now(timezone.utc),
         init=False
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), 
-        default=lambda: datetime.now(timezone.utc),
+        default_factory=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
         init=False
     )
@@ -102,7 +102,7 @@ class Coupon(Base):
     id: Mapped[str] = mapped_column(
         String(36),
         primary_key=True,
-        default=lambda: str(uuid.uuid4()),
+        default_factory=lambda: str(uuid.uuid4()),
         init=False
     )
     
@@ -195,12 +195,12 @@ class Coupon(Base):
     # Timestamps (excluded from __init__)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), 
-        default=lambda: datetime.now(timezone.utc),
+        default_factory=lambda: datetime.now(timezone.utc),
         init=False
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), 
-        default=lambda: datetime.now(timezone.utc),
+        default_factory=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
         init=False
     )
@@ -285,27 +285,29 @@ class UserFavorite(Base):
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
     coupon_id: Mapped[str] = mapped_column(ForeignKey("coupons.id", ondelete="CASCADE"))
     
-    # Notification Preferences
-    notify_price_drop: Mapped[bool] = mapped_column(Boolean, default=True)
-    notify_similar: Mapped[bool] = mapped_column(Boolean, default=False)
-    notify_expiry: Mapped[bool] = mapped_column(Boolean, default=True)
-    
-    # Tracking
+    # Tracking - שדות חובה לפני שדות עם ברירת מחדל
     original_price: Mapped[Decimal] = mapped_column(Numeric(10, 2))  # מחיר בזמן השמירה
-    price_alerts_sent: Mapped[int] = mapped_column(Integer, default=0)
     last_price_check: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
     
+    # Notification Preferences (עם ברירות מחדל)
+    notify_price_drop: Mapped[bool] = mapped_column(Boolean, default=True)
+    notify_similar: Mapped[bool] = mapped_column(Boolean, default=False)
+    notify_expiry: Mapped[bool] = mapped_column(Boolean, default=True)
+    
+    # Counters (עם ברירת מחדל)
+    price_alerts_sent: Mapped[int] = mapped_column(Integer, default=0)
+    
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), 
-        default=lambda: datetime.now(timezone.utc),
+        default_factory=lambda: datetime.now(timezone.utc),
         init=False
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), 
-        default=lambda: datetime.now(timezone.utc),
+        default_factory=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
         init=False
     )

--- a/app/models/coupon.py
+++ b/app/models/coupon.py
@@ -105,12 +105,30 @@ class Coupon(Base):
         default=lambda: str(uuid.uuid4()),
         init=False
     )
+    
+    # === Relationships (מיד אחרי ה-PK, לפני שדות עם ברירת מחדל) ===
+    seller: Mapped["User"] = relationship("User")
+    category: Mapped["CouponCategory"] = relationship("CouponCategory", back_populates="coupons")
+    
+    # Orders & Auctions
+    orders: Mapped[list["Order"]] = relationship(
+        "Order", back_populates="coupon", cascade="all, delete-orphan"
+    )
+    auctions: Mapped[list["Auction"]] = relationship(
+        "Auction", back_populates="coupon", cascade="all, delete-orphan"
+    )
+    
+    # Favorites & Notifications
+    favorites: Mapped[list["UserFavorite"]] = relationship(
+        "UserFavorite", back_populates="coupon", cascade="all, delete-orphan"
+    )
+
+    # === שדות חובה (ללא ברירת מחדל/nullable ב-init של dataclass) ===
     seller_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
     # לפי הדרישה: להציב expires_at מוקדם
     expires_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
-    # שדות חובה נוספים
     category_id: Mapped[str] = mapped_column(ForeignKey("coupon_categories.id"))
     title: Mapped[str] = mapped_column(String(200))
     description: Mapped[str] = mapped_column(Text)
@@ -185,23 +203,6 @@ class Coupon(Base):
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
         init=False
-    )
-    
-    # === Relationships ===
-    seller: Mapped["User"] = relationship("User")
-    category: Mapped["CouponCategory"] = relationship("CouponCategory", back_populates="coupons")
-    
-    # Orders & Auctions
-    orders: Mapped[list["Order"]] = relationship(
-        "Order", back_populates="coupon", cascade="all, delete-orphan"
-    )
-    auctions: Mapped[list["Auction"]] = relationship(
-        "Auction", back_populates="coupon", cascade="all, delete-orphan"
-    )
-    
-    # Favorites & Notifications
-    favorites: Mapped[list["UserFavorite"]] = relationship(
-        "UserFavorite", back_populates="coupon", cascade="all, delete-orphan"
     )
     
     # Indexes

--- a/app/models/coupon.py
+++ b/app/models/coupon.py
@@ -291,6 +291,10 @@ class UserFavorite(Base):
         DateTime(timezone=True), nullable=True
     )
     
+    # === Relationships ===
+    user: Mapped["User"] = relationship("User")
+    coupon: Mapped["Coupon"] = relationship("Coupon", back_populates="favorites")
+    
     # Notification Preferences (עם ברירות מחדל)
     notify_price_drop: Mapped[bool] = mapped_column(Boolean, default=True)
     notify_similar: Mapped[bool] = mapped_column(Boolean, default=False)
@@ -311,10 +315,6 @@ class UserFavorite(Base):
         onupdate=lambda: datetime.now(timezone.utc),
         init=False
     )
-    
-    # === Relationships ===
-    user: Mapped["User"] = relationship("User")
-    coupon: Mapped["Coupon"] = relationship("Coupon", back_populates="favorites")
     
     # Indexes & Constraints
     __table_args__ = (

--- a/app/models/coupon.py
+++ b/app/models/coupon.py
@@ -342,12 +342,6 @@ class CouponRating(Base):
     
     id: Mapped[int] = mapped_column(Integer, primary_key=True, init=False)
     
-    # === Relationships (מיד אחרי ה-PK, לפני שדות עם ברירת מחדל) ===
-    order: Mapped["Order"] = relationship("Order")
-    buyer: Mapped["User"] = relationship("User", foreign_keys=["CouponRating.buyer_id"])  # שימוש במחרוזת כדי לאפשר סדר
-    seller: Mapped["User"] = relationship("User", foreign_keys=["CouponRating.seller_id"])  # שימוש במחרוזת כדי לאפשר סדר
-    coupon: Mapped["Coupon"] = relationship("Coupon")
-    
     # Foreign Keys (שדות חובה)
     order_id: Mapped[str] = mapped_column(ForeignKey("orders.id", ondelete="CASCADE"))
     buyer_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
@@ -357,6 +351,12 @@ class CouponRating(Base):
     # Rating Details (חובה/nullable ללא ברירות מחדל)
     rating: Mapped[int] = mapped_column(Integer)  # 1-5 כוכבים
     comment: Mapped[Optional[str]] = mapped_column(String(150), nullable=True)  # עד 150 תווים
+    
+    # === Relationships ===
+    order: Mapped["Order"] = relationship("Order", foreign_keys=[order_id])
+    buyer: Mapped["User"] = relationship("User", foreign_keys=[buyer_id])
+    seller: Mapped["User"] = relationship("User", foreign_keys=[seller_id])
+    coupon: Mapped["Coupon"] = relationship("Coupon", foreign_keys=[coupon_id])
     
     # Metadata (עם ברירות מחדל)
     is_public: Mapped[bool] = mapped_column(Boolean, default=True)

--- a/app/models/coupon.py
+++ b/app/models/coupon.py
@@ -342,32 +342,32 @@ class CouponRating(Base):
     
     id: Mapped[int] = mapped_column(Integer, primary_key=True, init=False)
     
-    # Foreign Keys
+    # === Relationships (מיד אחרי ה-PK, לפני שדות עם ברירת מחדל) ===
+    order: Mapped["Order"] = relationship("Order")
+    buyer: Mapped["User"] = relationship("User", foreign_keys=["CouponRating.buyer_id"])  # שימוש במחרוזת כדי לאפשר סדר
+    seller: Mapped["User"] = relationship("User", foreign_keys=["CouponRating.seller_id"])  # שימוש במחרוזת כדי לאפשר סדר
+    coupon: Mapped["Coupon"] = relationship("Coupon")
+    
+    # Foreign Keys (שדות חובה)
     order_id: Mapped[str] = mapped_column(ForeignKey("orders.id", ondelete="CASCADE"))
     buyer_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
     seller_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
     coupon_id: Mapped[str] = mapped_column(ForeignKey("coupons.id", ondelete="CASCADE"))
     
-    # Rating Details
+    # Rating Details (חובה/nullable ללא ברירות מחדל)
     rating: Mapped[int] = mapped_column(Integer)  # 1-5 כוכבים
-    comment: Mapped[Optional[str]] = mapped_column(String(150), nullable=True)  # עד 15 תווים כמו בדרישות
+    comment: Mapped[Optional[str]] = mapped_column(String(150), nullable=True)  # עד 150 תווים
     
-    # Metadata
+    # Metadata (עם ברירות מחדל)
     is_public: Mapped[bool] = mapped_column(Boolean, default=True)
     is_verified_purchase: Mapped[bool] = mapped_column(Boolean, default=True)
     
-    # Timestamp
+    # Timestamp (מחוץ ל-__init__)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), 
-        default=lambda: datetime.now(timezone.utc),
+        default_factory=lambda: datetime.now(timezone.utc),
         init=False
     )
-    
-    # === Relationships ===
-    order: Mapped["Order"] = relationship("Order")
-    buyer: Mapped["User"] = relationship("User", foreign_keys=[buyer_id])
-    seller: Mapped["User"] = relationship("User", foreign_keys=[seller_id])
-    coupon: Mapped["Coupon"] = relationship("Coupon")
     
     # Indexes & Constraints
     __table_args__ = (

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -69,19 +69,16 @@ class Order(Base):
     seller_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
     coupon_id: Mapped[str] = mapped_column(ForeignKey("coupons.id", ondelete="CASCADE"))
     
-    # Order Details
+    # Order Details (ללא ברירות מחדל קודם)
     unit_price: Mapped[Decimal] = mapped_column(Numeric(10, 2))  # מחיר יחידה
     total_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2))  # סה"כ לפני עמלות
-    quantity: Mapped[int] = mapped_column(Integer, default=1)
     
     # Financial Breakdown - שדות חובה לפני שדות עם ברירת מחדל
     seller_amount_gross: Mapped[Decimal] = mapped_column(Numeric(12, 2))  # סכום מוכר ברוטו (לפני עמלה)
     seller_amount_net: Mapped[Decimal] = mapped_column(Numeric(12, 2))    # סכום מוכר נטו (אחרי עמלה)
-    buyer_fee: Mapped[Decimal] = mapped_column(Numeric(10, 2), default=Decimal('0.00'))  # עמלת קונה
-    seller_fee: Mapped[Decimal] = mapped_column(Numeric(10, 2), default=Decimal('0.00'))  # עמלת מוכר
+    
     
     # Status & Timing - תוספות חדשות קריטיות
-    status: Mapped[OrderStatus] = mapped_column(ENUM(OrderStatus), default=OrderStatus.PENDING)
     
     # Timing Fields - חדש וחשוב!
     created_at: Mapped[datetime] = mapped_column(
@@ -121,19 +118,10 @@ class Order(Base):
     )
     resolution_notes: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     
-    # Delivery Info
+    # Delivery Info (ללא ברירת מחדל)
     coupon_data: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # JSON
-    delivery_method: Mapped[str] = mapped_column(String(50), default="digital")
     delivered_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
-    )
-    
-    # Updated timestamp
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), 
-        default_factory=lambda: datetime.now(timezone.utc),
-        onupdate=lambda: datetime.now(timezone.utc),
-        init=False
     )
     
     # === Relationships ===
@@ -142,6 +130,21 @@ class Order(Base):
     coupon: Mapped["Coupon"] = relationship("Coupon", back_populates="orders")
     resolved_by_admin: Mapped[Optional["User"]] = relationship(
         "User", foreign_keys=[resolved_by_admin_id]
+    )
+
+    # שדות עם ברירת מחדל (סוף המחלקה עבור dataclass)
+    quantity: Mapped[int] = mapped_column(Integer, default=1)
+    status: Mapped[OrderStatus] = mapped_column(ENUM(OrderStatus), default=OrderStatus.PENDING)
+    delivery_method: Mapped[str] = mapped_column(String(50), default="digital")
+    buyer_fee: Mapped[Decimal] = mapped_column(Numeric(10, 2), default=Decimal('0.00'))  # עמלת קונה
+    seller_fee: Mapped[Decimal] = mapped_column(Numeric(10, 2), default=Decimal('0.00'))  # עמלת מוכר
+
+    # Updated timestamp
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), 
+        default_factory=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        init=False
     )
     
     # Indexes - חדש וחשוב לביצועים!

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -235,13 +235,7 @@ class Auction(Base):
         DateTime(timezone=True), nullable=True
     )  # הארכה אוטומטית
     
-    # Status
-    status: Mapped[AuctionStatus] = mapped_column(
-        ENUM(AuctionStatus), 
-        default=AuctionStatus.ACTIVE
-    )
-    
-    # Winner Info
+    # Winner Info (ללא ברירת מחדל)
     winner_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("users.id"), nullable=True
     )
@@ -250,23 +244,6 @@ class Auction(Base):
     )
     finalized_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
-    )
-    
-    # Stats
-    total_bids: Mapped[int] = mapped_column(Integer, default=0)
-    unique_bidders: Mapped[int] = mapped_column(Integer, default=0)
-    
-    # Timestamps
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), 
-        default_factory=lambda: datetime.now(timezone.utc),
-        init=False
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), 
-        default_factory=lambda: datetime.now(timezone.utc),
-        onupdate=lambda: datetime.now(timezone.utc),
-        init=False
     )
     
     # === Relationships ===
@@ -280,6 +257,24 @@ class Auction(Base):
         "AuctionBid", foreign_keys=[winning_bid_id]
     )
     
+    # Status (עם ברירת מחדל) ושדות סטטיסטיים עם ברירת מחדל
+    status: Mapped[AuctionStatus] = mapped_column(ENUM(AuctionStatus), default=AuctionStatus.ACTIVE)
+    total_bids: Mapped[int] = mapped_column(Integer, default=0)
+    unique_bidders: Mapped[int] = mapped_column(Integer, default=0)
+
+    # Timestamps
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), 
+        default_factory=lambda: datetime.now(timezone.utc),
+        init=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), 
+        default_factory=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        init=False
+    )
+
     # Indexes
     __table_args__ = (
         Index("idx_auctions_seller", "seller_id"),

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -406,7 +406,7 @@ def create_auction_order(auction: Auction, winning_bid: AuctionBid) -> Order:
     )
     
     # סימון שמקורו מכרז
-    order.metadata = f"auction:{auction.id}"
+    order.extra_metadata = f"auction:{auction.id}"
     
     return order
 

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -71,8 +71,8 @@ class Order(Base):
     
     # Order Details
     unit_price: Mapped[Decimal] = mapped_column(Numeric(10, 2))  # מחיר יחידה
-    quantity: Mapped[int] = mapped_column(Integer, default=1)
     total_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2))  # סה"כ לפני עמלות
+    quantity: Mapped[int] = mapped_column(Integer, default=1)
     
     # Financial Breakdown - תוספות חדשות חשובות
     buyer_fee: Mapped[Decimal] = mapped_column(

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -60,7 +60,7 @@ class Order(Base):
     id: Mapped[str] = mapped_column(
         String(36), 
         primary_key=True, 
-        default=lambda: str(uuid.uuid4()),
+        default_factory=lambda: str(uuid.uuid4()),
         init=False
     )
     
@@ -70,8 +70,8 @@ class Order(Base):
     coupon_id: Mapped[str] = mapped_column(ForeignKey("coupons.id", ondelete="CASCADE"))
     
     # Order Details
-    quantity: Mapped[int] = mapped_column(Integer, default=1)
     unit_price: Mapped[Decimal] = mapped_column(Numeric(10, 2))  # מחיר יחידה
+    quantity: Mapped[int] = mapped_column(Integer, default=1)
     total_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2))  # סה"כ לפני עמלות
     
     # Financial Breakdown - תוספות חדשות חשובות
@@ -94,7 +94,7 @@ class Order(Base):
     # Timing Fields - חדש וחשוב!
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), 
-        default=lambda: datetime.now(timezone.utc),
+        default_factory=lambda: datetime.now(timezone.utc),
         init=False
     )
     purchased_at: Mapped[Optional[datetime]] = mapped_column(
@@ -139,7 +139,7 @@ class Order(Base):
     # Updated timestamp
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), 
-        default=lambda: datetime.now(timezone.utc),
+        default_factory=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
         init=False
     )
@@ -218,7 +218,7 @@ class Auction(Base):
     id: Mapped[str] = mapped_column(
         String(36), 
         primary_key=True, 
-        default=lambda: str(uuid.uuid4()),
+        default_factory=lambda: str(uuid.uuid4()),
         init=False
     )
     
@@ -264,12 +264,12 @@ class Auction(Base):
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), 
-        default=lambda: datetime.now(timezone.utc),
+        default_factory=lambda: datetime.now(timezone.utc),
         init=False
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), 
-        default=lambda: datetime.now(timezone.utc),
+        default_factory=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
         init=False
     )
@@ -332,7 +332,7 @@ class AuctionBid(Base):
     id: Mapped[str] = mapped_column(
         String(36), 
         primary_key=True, 
-        default=lambda: str(uuid.uuid4()),
+        default_factory=lambda: str(uuid.uuid4()),
         init=False
     )
     
@@ -353,7 +353,7 @@ class AuctionBid(Base):
     # Timestamp
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), 
-        default=lambda: datetime.now(timezone.utc),
+        default_factory=lambda: datetime.now(timezone.utc),
         init=False
     )
     

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -326,19 +326,15 @@ class AuctionBid(Base):
         init=False
     )
     
-    # Foreign Keys
+    # Foreign Keys (ללא ברירות מחדל קודם)
     auction_id: Mapped[str] = mapped_column(ForeignKey("auctions.id", ondelete="CASCADE"))
     bidder_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    fund_lock_id: Mapped[Optional[str]] = mapped_column(ForeignKey("fund_locks.id"), nullable=True)
     
     # Bid Details
     amount: Mapped[Decimal] = mapped_column(Numeric(10, 2))
     is_winning: Mapped[bool] = mapped_column(Boolean, default=False)
     is_outbid: Mapped[bool] = mapped_column(Boolean, default=False)
-    
-    # Fund Lock Reference
-    fund_lock_id: Mapped[Optional[str]] = mapped_column(
-        ForeignKey("fund_locks.id"), nullable=True
-    )
     
     # Timestamp
     created_at: Mapped[datetime] = mapped_column(

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -74,19 +74,11 @@ class Order(Base):
     total_amount: Mapped[Decimal] = mapped_column(Numeric(12, 2))  # סה"כ לפני עמלות
     quantity: Mapped[int] = mapped_column(Integer, default=1)
     
-    # Financial Breakdown - תוספות חדשות חשובות
-    buyer_fee: Mapped[Decimal] = mapped_column(
-        Numeric(10, 2), default=Decimal('0.00')
-    )  # עמלת קונה
-    seller_fee: Mapped[Decimal] = mapped_column(
-        Numeric(10, 2), default=Decimal('0.00')  
-    )  # עמלת מוכר
-    seller_amount_gross: Mapped[Decimal] = mapped_column(
-        Numeric(12, 2)
-    )  # סכום מוכר ברוטו (לפני עמלה)
-    seller_amount_net: Mapped[Decimal] = mapped_column(
-        Numeric(12, 2)
-    )  # סכום מוכר נטו (אחרי עמלה)
+    # Financial Breakdown - שדות חובה לפני שדות עם ברירת מחדל
+    seller_amount_gross: Mapped[Decimal] = mapped_column(Numeric(12, 2))  # סכום מוכר ברוטו (לפני עמלה)
+    seller_amount_net: Mapped[Decimal] = mapped_column(Numeric(12, 2))    # סכום מוכר נטו (אחרי עמלה)
+    buyer_fee: Mapped[Decimal] = mapped_column(Numeric(10, 2), default=Decimal('0.00'))  # עמלת קונה
+    seller_fee: Mapped[Decimal] = mapped_column(Numeric(10, 2), default=Decimal('0.00'))  # עמלת מוכר
     
     # Status & Timing - תוספות חדשות קריטיות
     status: Mapped[OrderStatus] = mapped_column(ENUM(OrderStatus), default=OrderStatus.PENDING)

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -333,20 +333,22 @@ class AuctionBid(Base):
     
     # Bid Details
     amount: Mapped[Decimal] = mapped_column(Numeric(10, 2))
+
+    # === Relationships === (ללא ברירת מחדל – לפני שדות עם ברירת מחדל)
+    auction: Mapped["Auction"] = relationship("Auction", back_populates="bids")
+    bidder: Mapped["User"] = relationship("User")
+    fund_lock: Mapped[Optional["FundLock"]] = relationship("FundLock")
+
+    # Bid Flags (עם ברירות מחדל)
     is_winning: Mapped[bool] = mapped_column(Boolean, default=False)
     is_outbid: Mapped[bool] = mapped_column(Boolean, default=False)
-    
+
     # Timestamp
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), 
         default_factory=lambda: datetime.now(timezone.utc),
         init=False
     )
-    
-    # === Relationships ===
-    auction: Mapped["Auction"] = relationship("Auction", back_populates="bids")
-    bidder: Mapped["User"] = relationship("User")
-    fund_lock: Mapped[Optional["FundLock"]] = relationship("FundLock")
     
     # Indexes
     __table_args__ = (

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -251,7 +251,10 @@ class Auction(Base):
     coupon: Mapped["Coupon"] = relationship("Coupon", back_populates="auctions")
     winner: Mapped[Optional["User"]] = relationship("User", foreign_keys=[winner_id])
     bids: Mapped[list["AuctionBid"]] = relationship(
-        "AuctionBid", back_populates="auction", cascade="all, delete-orphan"
+        "AuctionBid",
+        back_populates="auction",
+        cascade="all, delete-orphan",
+        primaryjoin="Auction.id==AuctionBid.auction_id"
     )
     winning_bid: Mapped[Optional["AuctionBid"]] = relationship(
         "AuctionBid", foreign_keys=[winning_bid_id]
@@ -335,7 +338,12 @@ class AuctionBid(Base):
     amount: Mapped[Decimal] = mapped_column(Numeric(10, 2))
 
     # === Relationships === (ללא ברירת מחדל – לפני שדות עם ברירת מחדל)
-    auction: Mapped["Auction"] = relationship("Auction", back_populates="bids")
+    auction: Mapped["Auction"] = relationship(
+        "Auction",
+        back_populates="bids",
+        primaryjoin="AuctionBid.auction_id==Auction.id",
+        foreign_keys=[auction_id]
+    )
     bidder: Mapped["User"] = relationship("User")
     fund_lock: Mapped[Optional["FundLock"]] = relationship("FundLock")
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -71,7 +71,12 @@ class User(Base):
         "Wallet", back_populates="user", uselist=False, cascade="all, delete-orphan"
     )
     seller_profile: Mapped[Optional["SellerProfile"]] = relationship(
-        "SellerProfile", back_populates="user", uselist=False, cascade="all, delete-orphan"
+        "SellerProfile",
+        back_populates="user",
+        uselist=False,
+        cascade="all, delete-orphan",
+        foreign_keys=lambda: [SellerProfile.user_id],
+        primaryjoin=lambda: User.id == SellerProfile.user_id
     )
     transactions: Mapped[list["Transaction"]] = relationship(
         "Transaction", back_populates="user", cascade="all, delete-orphan"
@@ -140,7 +145,12 @@ class SellerProfile(Base):
     average_rating: Mapped[Optional[Decimal]] = mapped_column(Numeric(3, 2), nullable=True)
     
     # === Relationships === (ללא ברירות מחדל – לפני שדות עם ברירת מחדל)
-    user: Mapped["User"] = relationship("User", back_populates="seller_profile")
+    user: Mapped["User"] = relationship(
+        "User",
+        back_populates="seller_profile",
+        foreign_keys=lambda: [SellerProfile.user_id],
+        primaryjoin=lambda: User.id == SellerProfile.user_id
+    )
 
     # Defaulted fields (לבסוף)
     is_verified: Mapped[bool] = mapped_column(Boolean, default=False)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -287,6 +287,10 @@ class Transaction(Base):
     metadata: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # JSON נוסף
     processed_by_admin_id: Mapped[Optional[int]] = mapped_column(ForeignKey("users.id"), nullable=True)
 
+    # === Relationships === (ללא ברירות מחדל – לפני שדות עם ברירת מחדל)
+    user: Mapped["User"] = relationship("User", back_populates="transactions")
+    wallet: Mapped["Wallet"] = relationship("Wallet", back_populates="transactions")
+
     # Defaults
     locked_before: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=Decimal('0.00'))
     locked_after: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=Decimal('0.00'))
@@ -297,10 +301,6 @@ class Transaction(Base):
         default_factory=lambda: datetime.now(timezone.utc),
         init=False
     )
-    
-    # === Relationships ===
-    user: Mapped["User"] = relationship("User", back_populates="transactions")
-    wallet: Mapped["Wallet"] = relationship("Wallet", back_populates="transactions")
     
     # Indexes
     __table_args__ = (

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -66,7 +66,19 @@ class User(Base):
     first_name: Mapped[str] = mapped_column(String(100))
     last_name: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     
-    # Role & Status (שדות עם ברירת מחדל יבואו אחרי שדות ללא ברירת מחדל)
+    # === Relationships === (ללא ברירות מחדל – להופיע לפני שדות עם ברירת מחדל)
+    wallet: Mapped[Optional["Wallet"]] = relationship(
+        "Wallet", back_populates="user", uselist=False, cascade="all, delete-orphan"
+    )
+    seller_profile: Mapped[Optional["SellerProfile"]] = relationship(
+        "SellerProfile", back_populates="user", uselist=False, cascade="all, delete-orphan"
+    )
+    transactions: Mapped[list["Transaction"]] = relationship(
+        "Transaction", back_populates="user", cascade="all, delete-orphan"
+    )
+    fund_locks: Mapped[list["FundLock"]] = relationship(
+        "FundLock", back_populates="user", cascade="all, delete-orphan"
+    )
     
     # Contact Info (עבור מוכרים) - ללא ברירת מחדל
     phone: Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
@@ -94,19 +106,7 @@ class User(Base):
     
     # Contact Info הוזז למעלה
     
-    # === Relationships === (ללא ברירות מחדל – להופיע לפני שדות עם ברירת מחדל)
-    wallet: Mapped[Optional["Wallet"]] = relationship(
-        "Wallet", back_populates="user", uselist=False, cascade="all, delete-orphan"
-    )
-    seller_profile: Mapped[Optional["SellerProfile"]] = relationship(
-        "SellerProfile", back_populates="user", uselist=False, cascade="all, delete-orphan"
-    )
-    transactions: Mapped[list["Transaction"]] = relationship(
-        "Transaction", back_populates="user", cascade="all, delete-orphan"
-    )
-    fund_locks: Mapped[list["FundLock"]] = relationship(
-        "FundLock", back_populates="user", cascade="all, delete-orphan"
-    )
+    # Relationships הוזזו למעלה
     
     # Indexes
     __table_args__ = (

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -284,7 +284,7 @@ class Transaction(Base):
     balance_after: Mapped[Decimal] = mapped_column(Numeric(12, 2))
 
     # Non-default optional fields (לפני ברירות מחדל)
-    metadata: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # JSON נוסף
+    extra_metadata: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # JSON נוסף
     processed_by_admin_id: Mapped[Optional[int]] = mapped_column(ForeignKey("users.id"), nullable=True)
 
     # === Relationships === (ללא ברירות מחדל – לפני שדות עם ברירת מחדל)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -79,7 +79,11 @@ class User(Base):
         primaryjoin=lambda: User.id == SellerProfile.user_id
     )
     transactions: Mapped[list["Transaction"]] = relationship(
-        "Transaction", back_populates="user", cascade="all, delete-orphan"
+        "Transaction",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        foreign_keys=lambda: [Transaction.user_id],
+        primaryjoin=lambda: User.id == Transaction.user_id
     )
     fund_locks: Mapped[list["FundLock"]] = relationship(
         "FundLock", back_populates="user", cascade="all, delete-orphan"
@@ -298,8 +302,18 @@ class Transaction(Base):
     processed_by_admin_id: Mapped[Optional[int]] = mapped_column(ForeignKey("users.id"), nullable=True)
 
     # === Relationships === (ללא ברירות מחדל – לפני שדות עם ברירת מחדל)
-    user: Mapped["User"] = relationship("User", back_populates="transactions")
-    wallet: Mapped["Wallet"] = relationship("Wallet", back_populates="transactions")
+    user: Mapped["User"] = relationship(
+        "User",
+        back_populates="transactions",
+        foreign_keys=lambda: [Transaction.user_id],
+        primaryjoin=lambda: Transaction.user_id == User.id
+    )
+    wallet: Mapped["Wallet"] = relationship(
+        "Wallet",
+        back_populates="transactions",
+        foreign_keys=lambda: [Transaction.wallet_id],
+        primaryjoin=lambda: Transaction.wallet_id == Wallet.id
+    )
 
     # Defaults
     locked_before: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=Decimal('0.00'))

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -94,7 +94,7 @@ class User(Base):
     
     # Contact Info הוזז למעלה
     
-    # === Relationships ===
+    # === Relationships === (ללא ברירות מחדל – להופיע לפני שדות עם ברירת מחדל)
     wallet: Mapped[Optional["Wallet"]] = relationship(
         "Wallet", back_populates="user", uselist=False, cascade="all, delete-orphan"
     )

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -71,21 +71,21 @@ class User(Base):
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     is_blocked: Mapped[bool] = mapped_column(Boolean, default=False)
     
-    # Timestamps
+    # Timestamps - שדה ללא ברירת מחדל לפני שדות עם ברירת מחדל
+    last_activity_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), 
+        nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), 
-        default=lambda: datetime.now(timezone.utc),
+        default_factory=lambda: datetime.now(timezone.utc),
         init=False
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), 
-        default=lambda: datetime.now(timezone.utc),
+        default_factory=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
         init=False
-    )
-    last_activity_at: Mapped[Optional[datetime]] = mapped_column(
-        DateTime(timezone=True), 
-        nullable=True
     )
     
     # Contact Info (עבור מוכרים)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -346,6 +346,12 @@ class FundLock(Base):
     released_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+
+    # === Relationships === (ללא ברירת מחדל – לפני שדות עם ברירת מחדל)
+    user: Mapped["User"] = relationship("User", back_populates="fund_locks")
+    wallet: Mapped["Wallet"] = relationship("Wallet", back_populates="fund_locks")
+
+    # שדות עם ברירת מחדל
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     
     # Timestamps
@@ -354,11 +360,6 @@ class FundLock(Base):
         default_factory=lambda: datetime.now(timezone.utc),
         init=False
     )
-    
-    
-    # === Relationships ===
-    user: Mapped["User"] = relationship("User", back_populates="fund_locks")
-    wallet: Mapped["Wallet"] = relationship("Wallet", back_populates="fund_locks")
     
     # Indexes
     __table_args__ = (

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -66,16 +66,16 @@ class User(Base):
     first_name: Mapped[str] = mapped_column(String(100))
     last_name: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     
-    # Role & Status
-    role: Mapped[UserRole] = mapped_column(ENUM(UserRole), default=UserRole.BUYER)
-    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
-    is_blocked: Mapped[bool] = mapped_column(Boolean, default=False)
+    # Role & Status (שדות עם ברירת מחדל יבואו אחרי last_activity_at)
     
     # Timestamps - שדה ללא ברירת מחדל לפני שדות עם ברירת מחדל
     last_activity_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), 
         nullable=True
     )
+    role: Mapped[UserRole] = mapped_column(ENUM(UserRole), default=UserRole.BUYER)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    is_blocked: Mapped[bool] = mapped_column(Boolean, default=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), 
         default_factory=lambda: datetime.now(timezone.utc),

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -202,7 +202,16 @@ class Wallet(Base):
     
     id: Mapped[int] = mapped_column(Integer, primary_key=True, init=False)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), unique=True)
-    
+
+    # === Relationships === (ללא ברירת מחדל – לפני שדות עם ברירת מחדל)
+    user: Mapped["User"] = relationship("User", back_populates="wallet")
+    transactions: Mapped[list["Transaction"]] = relationship(
+        "Transaction", back_populates="wallet", cascade="all, delete-orphan"
+    )
+    fund_locks: Mapped[list["FundLock"]] = relationship(
+        "FundLock", back_populates="wallet", cascade="all, delete-orphan"
+    )
+
     # יתרות - עדכון לפי הדרישות החדשות
     total_balance: Mapped[Decimal] = mapped_column(
         Numeric(12, 2), default=Decimal('0.00')
@@ -210,27 +219,18 @@ class Wallet(Base):
     locked_balance: Mapped[Decimal] = mapped_column(
         Numeric(12, 2), default=Decimal('0.00')
     )  # 🔒 יתרה קפואה (מכרזים + holds)
-    
+
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), 
-        default=lambda: datetime.now(timezone.utc),
+        default_factory=lambda: datetime.now(timezone.utc),
         init=False
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), 
-        default=lambda: datetime.now(timezone.utc),
+        default_factory=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
         init=False
-    )
-    
-    # === Relationships ===
-    user: Mapped["User"] = relationship("User", back_populates="wallet")
-    transactions: Mapped[list["Transaction"]] = relationship(
-        "Transaction", back_populates="wallet", cascade="all, delete-orphan"
-    )
-    fund_locks: Mapped[list["FundLock"]] = relationship(
-        "FundLock", back_populates="wallet", cascade="all, delete-orphan"
     )
     
     # Constraints

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -323,7 +323,7 @@ class FundLock(Base):
     id: Mapped[str] = mapped_column(
         String(36), 
         primary_key=True, 
-        default=lambda: str(uuid.uuid4()),
+        default_factory=lambda: str(uuid.uuid4()),
         init=False
     )
     
@@ -339,16 +339,16 @@ class FundLock(Base):
     reference_type: Mapped[str] = mapped_column(String(50))  # "auction", "order"
     reference_id: Mapped[str] = mapped_column(String(100))
     
-    # Status & Timing
-    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    # Status & Timing (שדות ללא ברירת מחדל לפני עם ברירת מחדל)
     expires_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     
     # Timestamps
     locked_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), 
-        default=lambda: datetime.now(timezone.utc),
+        default_factory=lambda: datetime.now(timezone.utc),
         init=False
     )
     released_at: Mapped[Optional[datetime]] = mapped_column(

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -132,16 +132,16 @@ class SellerProfile(Base):
     description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     verification_documents: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # JSON
     
-    # Verification - סדר: שדות ללא ברירת מחדל לפני ברירת מחדל
+    # Non-default verification fields
     verified_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    verified_by_admin_id: Mapped[Optional[int]] = mapped_column(ForeignKey("users.id"), nullable=True)
+    
+    # Non-default stats field (צריך להופיע לפני שדות עם ברירת מחדל)
+    average_rating: Mapped[Optional[Decimal]] = mapped_column(Numeric(3, 2), nullable=True)
+    
+    # Defaulted fields (לבסוף)
     is_verified: Mapped[bool] = mapped_column(Boolean, default=False)
-    verification_status: Mapped[VerificationStatus] = mapped_column(
-        ENUM(VerificationStatus), 
-        default=VerificationStatus.UNVERIFIED
-    )
-    verified_by_admin_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("users.id"), nullable=True
-    )
+    verification_status: Mapped[VerificationStatus] = mapped_column(ENUM(VerificationStatus), default=VerificationStatus.UNVERIFIED)
     
     # Daily Limits - חדש
     daily_quota: Mapped[int] = mapped_column(Integer, default=10)  # 10 קופונים לליא מאומת
@@ -151,11 +151,8 @@ class SellerProfile(Base):
         default_factory=lambda: datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
     )
     
-    # Stats & Rating
+    # Stats & Rating (עם ברירות מחדל)
     total_sales: Mapped[int] = mapped_column(Integer, default=0)
-    average_rating: Mapped[Optional[Decimal]] = mapped_column(
-        Numeric(3, 2), nullable=True  # 0.00 - 5.00
-    )
     total_ratings: Mapped[int] = mapped_column(Integer, default=0)
     
     # Timestamps

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -130,14 +130,14 @@ class SellerProfile(Base):
     # Business Info
     business_name: Mapped[str] = mapped_column(String(200))
     description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    verification_documents: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # JSON
     
-    # Verification - תוספות חדשות
+    # Verification - תוספות חדשות (עם ברירות מחדל)
     is_verified: Mapped[bool] = mapped_column(Boolean, default=False)
     verification_status: Mapped[VerificationStatus] = mapped_column(
         ENUM(VerificationStatus), 
         default=VerificationStatus.UNVERIFIED
     )
-    verification_documents: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # JSON
     verified_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     verified_by_admin_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("users.id"), nullable=True
@@ -148,7 +148,7 @@ class SellerProfile(Base):
     daily_count: Mapped[int] = mapped_column(Integer, default=0)   # מונה נוכחי
     quota_reset_date: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
-        default=lambda: datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+        default_factory=lambda: datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
     )
     
     # Stats & Rating
@@ -161,12 +161,12 @@ class SellerProfile(Base):
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), 
-        default=lambda: datetime.now(timezone.utc),
+        default_factory=lambda: datetime.now(timezone.utc),
         init=False
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), 
-        default=lambda: datetime.now(timezone.utc),
+        default_factory=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
         init=False
     )

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -66,9 +66,13 @@ class User(Base):
     first_name: Mapped[str] = mapped_column(String(100))
     last_name: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     
-    # Role & Status (שדות עם ברירת מחדל יבואו אחרי last_activity_at)
+    # Role & Status (שדות עם ברירת מחדל יבואו אחרי שדות ללא ברירת מחדל)
     
-    # Timestamps - שדה ללא ברירת מחדל לפני שדות עם ברירת מחדל
+    # Contact Info (עבור מוכרים) - ללא ברירת מחדל
+    phone: Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
+    email: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
+    
+    # Timestamps / Status ordering
     last_activity_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), 
         nullable=True
@@ -88,9 +92,7 @@ class User(Base):
         init=False
     )
     
-    # Contact Info (עבור מוכרים)
-    phone: Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
-    email: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
+    # Contact Info הוזז למעלה
     
     # === Relationships ===
     wallet: Mapped[Optional["Wallet"]] = relationship(

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -139,6 +139,9 @@ class SellerProfile(Base):
     # Non-default stats field (צריך להופיע לפני שדות עם ברירת מחדל)
     average_rating: Mapped[Optional[Decimal]] = mapped_column(Numeric(3, 2), nullable=True)
     
+    # === Relationships === (ללא ברירות מחדל – לפני שדות עם ברירת מחדל)
+    user: Mapped["User"] = relationship("User", back_populates="seller_profile")
+
     # Defaulted fields (לבסוף)
     is_verified: Mapped[bool] = mapped_column(Boolean, default=False)
     verification_status: Mapped[VerificationStatus] = mapped_column(ENUM(VerificationStatus), default=VerificationStatus.UNVERIFIED)
@@ -167,9 +170,6 @@ class SellerProfile(Base):
         onupdate=lambda: datetime.now(timezone.utc),
         init=False
     )
-    
-    # === Relationships ===
-    user: Mapped["User"] = relationship("User", back_populates="seller_profile")
     
     # Indexes
     __table_args__ = (

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -343,6 +343,9 @@ class FundLock(Base):
     expires_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    released_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     
     # Timestamps
@@ -351,9 +354,7 @@ class FundLock(Base):
         default_factory=lambda: datetime.now(timezone.utc),
         init=False
     )
-    released_at: Mapped[Optional[datetime]] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    
     
     # === Relationships ===
     user: Mapped["User"] = relationship("User", back_populates="fund_locks")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -262,7 +262,7 @@ class Transaction(Base):
     id: Mapped[str] = mapped_column(
         String(36), 
         primary_key=True, 
-        default=lambda: str(uuid.uuid4()),
+        default_factory=lambda: str(uuid.uuid4()),
         init=False
     )
     
@@ -282,19 +282,19 @@ class Transaction(Base):
     # Balances After Transaction
     balance_before: Mapped[Decimal] = mapped_column(Numeric(12, 2))
     balance_after: Mapped[Decimal] = mapped_column(Numeric(12, 2))
+
+    # Non-default optional fields (לפני ברירות מחדל)
+    metadata: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # JSON נוסף
+    processed_by_admin_id: Mapped[Optional[int]] = mapped_column(ForeignKey("users.id"), nullable=True)
+
+    # Defaults
     locked_before: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=Decimal('0.00'))
     locked_after: Mapped[Decimal] = mapped_column(Numeric(12, 2), default=Decimal('0.00'))
-    
-    # Metadata
-    metadata: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # JSON נוסף
-    processed_by_admin_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("users.id"), nullable=True
-    )
     
     # Timestamp
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), 
-        default=lambda: datetime.now(timezone.utc),
+        default_factory=lambda: datetime.now(timezone.utc),
         init=False
     )
     

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -132,13 +132,13 @@ class SellerProfile(Base):
     description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     verification_documents: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # JSON
     
-    # Verification - תוספות חדשות (עם ברירות מחדל)
+    # Verification - סדר: שדות ללא ברירת מחדל לפני ברירת מחדל
+    verified_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     is_verified: Mapped[bool] = mapped_column(Boolean, default=False)
     verification_status: Mapped[VerificationStatus] = mapped_column(
         ENUM(VerificationStatus), 
         default=VerificationStatus.UNVERIFIED
     )
-    verified_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     verified_by_admin_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("users.id"), nullable=True
     )

--- a/app/services/wallet_service.py
+++ b/app/services/wallet_service.py
@@ -144,7 +144,7 @@ class WalletService:
             description=description,
             reference_type=reference_type,
             reference_id=reference_id,
-            metadata=metadata,
+            extra_metadata=metadata,
             processed_by_admin_id=admin_id,
             balance_before=balance_before,
             balance_after=wallet.total_balance,


### PR DESCRIPTION
<section> <h2>תיקון סדר שדות Dataclass, יחסים מפורשים, ו‑CI ירוק ✅</h2> <p> PR זה מטפל בשגיאות Dataclasses ו‑SQLAlchemy שמנעו טעינת מודלים והרצת טסטים. סידרתי את סדר השדות בכל המודלים, הוספתי foreign_keys/primaryjoin היכן שהיה עמימות, וטיפלתי בשדות ברירת מחדל כדי למנוע TypeError ו‑SADeprecationWarning. כל הטסטים ירוקים. </p> <h3>מה שונה</h3> <ul> <li><b>סדר שדות במחלקות (Dataclasses)</b>: כל שדה חובה לפני שדות עם ברירת מחדל/nullable.</li> <li><b>Relationships</b>: הוגדרו <code>foreign_keys</code>/<code>primaryjoin</code> היכן שהיה צורך: <ul> <li><code>Auction.bids</code> ↔ <code>AuctionBid.auction</code></li> <li><code>User.seller_profile</code> ↔ <code>SellerProfile.user</code></li> <li><code>User.transactions</code> ↔ <code>Transaction.user</code></li> <li><code>Transaction.wallet</code> ↔ <code>Wallet.transactions</code></li> <li><code>CouponRating</code>: שימוש בעמודות FK אמיתיות (לא מחרוזות)</li> </ul> </li> <li><b>שיפור ברירות מחדל</b>: מעבר מ‑<code>default=</code> ל‑<code>default_factory=</code> עבור <code>id</code> ו‑timestamps כדי להסיר אזהרות SA.</li> <li><b>שינוי שם שדה שמור</b>: <code>Transaction.metadata</code> הוחלף ל‑<code>extra_metadata</code> + עדכון שימושים.</li> <li><b>CI (GitHub Actions)</b>: קובץ <code>.github/workflows/tests.yml</code> מריץ pytest על כל push/PR עם Python 3.11, התקנות, ו‑PYTHONPATH לשורש הפרויקט.</li> </ul> <h3>מודלים שנגעתי בהם</h3> <ul> <li><b>Coupon</b>: סדר שדות ב‑<code>Coupon</code>, <code>UserFavorite</code>, <code>CouponRating</code>.</li> <li><b>Order</b>: סדר שדות ב‑<code>Order</code>, <code>Auction</code>, <code>AuctionBid</code> + יחסים מפורשים.</li> <li><b>User</b>: סדר שדות ב‑<code>User</code>, <code>SellerProfile</code>, <code>Wallet</code>, <code>Transaction</code>, <code>FundLock</code> + יחסים מפורשים.</li> </ul> <h3>למה זה חשוב</h3> <ul> <li><b>אין יותר TypeError</b>: שדות חובה מופיעים לפני ברירות מחדל.</li> <li><b>אין עמימות ביחסים</b>: SQLAlchemy יודע בדיוק על אילו FK להתחבר.</li> <li><b>פחות אזהרות</b>: שימוש ב‑<code>default_factory</code> במקום <code>default</code>.</li> <li><b>CI ירוק</b>: טעינת מודלים והגדרת mappers עוברים.</li> </ul> <h3>איך לבדוק</h3> <pre><code>pytest -q </code></pre> <h3>שינויים דורשי תשומת לב</h3> <ul> <li><b>שינוי שם עמודה</b>: <code>Transaction.metadata → extra_metadata</code>. אם קיימת טבלה/נתונים – נדרשת מיגרציה ב‑Alembic.</li> <li><b>שינוי סדר שדות</b>: אינו משנה סכמת DB, אבל משנה חתימות <code>__init__</code> של המודלים (MappedAsDataclass).</li> </ul> <h3>תוצאה</h3> <p> כל הטסטים ירוקים, המודלים נטענים בלי שגיאות סדר שדות או עמימות ביחסים, וה‑CI רץ אוטומטית על כל שינוי. </p> </section>

---
<a href="https://cursor.com/background-agent?bcId=bc-4e00947e-0e00-486f-ac98-43e66622f4d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4e00947e-0e00-486f-ac98-43e66622f4d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

