### PR TITLE
Update database engine to asyncpg

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -103,6 +103,13 @@ class Settings(BaseSettings):
             raise ValueError(f"ENVIRONMENT must be one of: {allowed}")
         return v
     
+    @validator("DATABASE_URL", pre=True)
+    def coerce_database_url_to_asyncpg(cls, v):
+        """המרת postgresql:// ל-postgresql+asyncpg:// לשימוש אסינכרוני"""
+        if isinstance(v, str) and v.startswith("postgresql://"):
+            return "postgresql+asyncpg://" + v[len("postgresql://"):]
+        return v
+
     @validator("DATABASE_URL")
     def validate_database_url(cls, v):
         """וידוא כתובת מסד נתונים תקינה"""

--- a/app/database.py
+++ b/app/database.py
@@ -70,7 +70,7 @@ class DatabaseManager:
                         "application_name": f"{settings.APP_NAME}_v{settings.VERSION}"
                     },
                     "command_timeout": 60,
-                    "prepared_statement_cache_size": 0,  # נמנע מ-cache problems
+                    "statement_cache_size": 0,  # נמנע מ-cache problems
                 }
             )
             

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ gunicorn==23.0.0
 sqlalchemy[asyncio]==2.0.35
 asyncpg==0.29.0
 alembic==1.13.3
-psycopg2-binary==2.9.9
 
 # הגדרות ו-Environment Variables
 pydantic-settings==2.5.2


### PR DESCRIPTION
Switch from `psycopg2` to `asyncpg` for asynchronous database operations.

This PR removes `psycopg2-binary`, adds a `DATABASE_URL` validator to automatically use `postgresql+asyncpg://`, and updates the `connect_args` in `app/database.py` to use `statement_cache_size` which is appropriate for `asyncpg`.

---
<a href="https://cursor.com/background-agent?bcId=bc-5cb605dd-ad4a-4f84-87de-fe77ed9c3c19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5cb605dd-ad4a-4f84-87de-fe77ed9c3c19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

