### PR TITLE
Update project to use asyncpg

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -112,9 +112,9 @@ class Settings(BaseSettings):
 
     @validator("DATABASE_URL")
     def validate_database_url(cls, v):
-        """וידוא כתובת מסד נתונים תקינה"""
-        if not v.startswith(("postgresql://", "postgresql+asyncpg://")):
-            raise ValueError("DATABASE_URL must be a PostgreSQL connection string")
+        """וידוא שהכתובת משתמשת בדרייבר asyncpg בלבד"""
+        if not isinstance(v, str) or not v.startswith("postgresql+asyncpg://"):
+            raise ValueError("DATABASE_URL must start with 'postgresql+asyncpg://' (async driver)")
         return v
     
     @property


### PR DESCRIPTION
Enforce `postgresql+asyncpg://` schema for `DATABASE_URL` to ensure exclusive use of the asyncpg driver.

This change aligns with the project's shift to using only `asyncpg` for asynchronous PostgreSQL connections, removing `psycopg2` and `psycopg2-binary` dependencies, and utilizing `create_async_engine`.

---
<a href="https://cursor.com/background-agent?bcId=bc-49ee1435-c10c-49c6-9809-ecbae774afaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-49ee1435-c10c-49c6-9809-ecbae774afaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

