### PR TITLE
Fix user model optional fields and relationships

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -66,37 +66,15 @@ class User(Base):
     first_name: Mapped[str] = mapped_column(String(100))
     last_name: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     
-    # === Relationships === (ללא ברירות מחדל – להופיע לפני שדות עם ברירת מחדל)
-    wallet: Mapped[Optional["Wallet"]] = relationship(
-        "Wallet", back_populates="user", uselist=False, cascade="all, delete-orphan"
-    )
-    seller_profile: Mapped[Optional["SellerProfile"]] = relationship(
-        "SellerProfile",
-        back_populates="user",
-        uselist=False,
-        cascade="all, delete-orphan",
-        foreign_keys=lambda: [SellerProfile.user_id],
-        primaryjoin=lambda: User.id == SellerProfile.user_id
-    )
-    transactions: Mapped[list["Transaction"]] = relationship(
-        "Transaction",
-        back_populates="user",
-        cascade="all, delete-orphan",
-        foreign_keys=lambda: [Transaction.user_id],
-        primaryjoin=lambda: User.id == Transaction.user_id
-    )
-    fund_locks: Mapped[list["FundLock"]] = relationship(
-        "FundLock", back_populates="user", cascade="all, delete-orphan"
-    )
-    
-    # Contact Info (עבור מוכרים) - ללא ברירת מחדל
-    phone: Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
-    email: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
+    # Contact Info (עבור מוכרים) - שדות אופציונליים
+    phone: Mapped[Optional[str]] = mapped_column(String(20), nullable=True, default=None)
+    email: Mapped[Optional[str]] = mapped_column(String(200), nullable=True, default=None)
     
     # Timestamps / Status ordering
     last_activity_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), 
-        nullable=True
+        nullable=True,
+        default_factory=lambda: datetime.now(timezone.utc)
     )
     role: Mapped[UserRole] = mapped_column(ENUM(UserRole), default=UserRole.BUYER)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
@@ -113,9 +91,30 @@ class User(Base):
         init=False
     )
     
-    # Contact Info הוזז למעלה
-    
-    # Relationships הוזזו למעלה
+    # === Relationships === (עם ברירות מחדל כדי שלא יהיו חובה ב-__init__)
+    wallet: Mapped[Optional["Wallet"]] = relationship(
+        "Wallet", back_populates="user", uselist=False, cascade="all, delete-orphan", default=None
+    )
+    seller_profile: Mapped[Optional["SellerProfile"]] = relationship(
+        "SellerProfile",
+        back_populates="user",
+        uselist=False,
+        cascade="all, delete-orphan",
+        foreign_keys=lambda: [SellerProfile.user_id],
+        primaryjoin=lambda: User.id == SellerProfile.user_id,
+        default=None
+    )
+    transactions: Mapped[list["Transaction"]] = relationship(
+        "Transaction",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        foreign_keys=lambda: [Transaction.user_id],
+        primaryjoin=lambda: User.id == Transaction.user_id,
+        default_factory=list
+    )
+    fund_locks: Mapped[list["FundLock"]] = relationship(
+        "FundLock", back_populates="user", cascade="all, delete-orphan", default_factory=list
+    )
     
     # Indexes
     __table_args__ = (

--- a/tests/test_user_creation_minimal.py
+++ b/tests/test_user_creation_minimal.py
@@ -1,0 +1,40 @@
+import pytest
+
+from app.models.user import User, UserRole
+
+
+def test_create_user_minimal_buyer() -> None:
+    user = User(
+        telegram_user_id=111111111,
+        username="testbuyer",
+        first_name="Test",
+        last_name="Buyer",
+    )
+
+    assert user.telegram_user_id == 111111111
+    assert user.first_name == "Test"
+    assert user.username == "testbuyer"
+
+    # שדות אופציונליים/קשרים לא נדרשים ב-__init__
+    assert user.phone is None
+    assert user.email is None
+    assert user.last_activity_at is not None
+    assert user.wallet is None
+    assert len(user.transactions) == 0
+    assert len(user.fund_locks) == 0
+
+
+def test_create_user_minimal_seller() -> None:
+    user = User(
+        telegram_user_id=222222222,
+        username="testseller",
+        first_name="Test",
+        last_name="Seller",
+        role=UserRole.SELLER,
+    )
+
+    assert user.telegram_user_id == 222222222
+    assert user.role == UserRole.SELLER
+    assert user.wallet is None
+    assert len(user.transactions) == 0
+    assert len(user.fund_locks) == 0


### PR DESCRIPTION
Make `User` model fields and relationships optional in `__init__` and reorder them to fix user creation errors.

This addresses the `__init__() missing required positional arguments` error by providing defaults for optional fields (`phone`, `email`, `last_activity_at`) and relationships (`wallet`, `seller_profile`, `transactions`, `fund_locks`), and reordering fields according to SQLAlchemy dataclass rules. Now, a `User` can be created with only essential parameters.

---
<a href="https://cursor.com/background-agent?bcId=bc-5c4e5fdd-eea4-4f28-8114-6a40b9d3f2ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5c4e5fdd-eea4-4f28-8114-6a40b9d3f2ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

