### PR TITLE
Update user id column to bigint

### DIFF
--- a/alembic/versions/20250921_01_users_id_bigint.py
+++ b/alembic/versions/20250921_01_users_id_bigint.py
@@ -1,0 +1,104 @@
+"""change users.id and related FKs to BIGINT
+
+Revision ID: 20250921_01
+Revises: 20250920_01
+Create Date: 2025-09-21
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "20250921_01"
+down_revision = "20250920_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1) לשדרג את ה-PK של users ל-BIGINT
+    op.execute(
+        """
+        ALTER TABLE users 
+        ALTER COLUMN id 
+        TYPE BIGINT 
+        USING id::BIGINT;
+        """
+    )
+
+    # 2) לעדכן את ה-sequence ל-BIGINT
+    op.execute("ALTER SEQUENCE users_id_seq AS BIGINT;")
+
+    # 3) לעדכן את כל ה-FK Columns ל-BIGINT
+    statements = [
+        # user.py models
+        "ALTER TABLE seller_profiles ALTER COLUMN user_id TYPE BIGINT USING user_id::BIGINT;",
+        "ALTER TABLE seller_profiles ALTER COLUMN verified_by_admin_id TYPE BIGINT USING verified_by_admin_id::BIGINT;",
+        "ALTER TABLE wallets ALTER COLUMN user_id TYPE BIGINT USING user_id::BIGINT;",
+        "ALTER TABLE transactions ALTER COLUMN user_id TYPE BIGINT USING user_id::BIGINT;",
+        "ALTER TABLE transactions ALTER COLUMN processed_by_admin_id TYPE BIGINT USING processed_by_admin_id::BIGINT;",
+        "ALTER TABLE fund_locks ALTER COLUMN user_id TYPE BIGINT USING user_id::BIGINT;",
+
+        # order.py models
+        "ALTER TABLE orders ALTER COLUMN buyer_id TYPE BIGINT USING buyer_id::BIGINT;",
+        "ALTER TABLE orders ALTER COLUMN seller_id TYPE BIGINT USING seller_id::BIGINT;",
+        "ALTER TABLE orders ALTER COLUMN resolved_by_admin_id TYPE BIGINT USING resolved_by_admin_id::BIGINT;",
+        "ALTER TABLE auctions ALTER COLUMN seller_id TYPE BIGINT USING seller_id::BIGINT;",
+        "ALTER TABLE auctions ALTER COLUMN winner_id TYPE BIGINT USING winner_id::BIGINT;",
+        "ALTER TABLE auction_bids ALTER COLUMN bidder_id TYPE BIGINT USING bidder_id::BIGINT;",
+
+        # coupon.py models
+        "ALTER TABLE coupons ALTER COLUMN seller_id TYPE BIGINT USING seller_id::BIGINT;",
+        "ALTER TABLE user_favorites ALTER COLUMN user_id TYPE BIGINT USING user_id::BIGINT;",
+        "ALTER TABLE coupon_ratings ALTER COLUMN buyer_id TYPE BIGINT USING buyer_id::BIGINT;",
+        "ALTER TABLE coupon_ratings ALTER COLUMN seller_id TYPE BIGINT USING seller_id::BIGINT;",
+    ]
+
+    for stmt in statements:
+        op.execute(stmt)
+
+
+def downgrade() -> None:
+    # החזרה של ה-FK Columns ל-INTEGER
+    statements = [
+        # coupon.py models
+        "ALTER TABLE coupon_ratings ALTER COLUMN seller_id TYPE INTEGER USING seller_id::INTEGER;",
+        "ALTER TABLE coupon_ratings ALTER COLUMN buyer_id TYPE INTEGER USING buyer_id::INTEGER;",
+        "ALTER TABLE user_favorites ALTER COLUMN user_id TYPE INTEGER USING user_id::INTEGER;",
+        "ALTER TABLE coupons ALTER COLUMN seller_id TYPE INTEGER USING seller_id::INTEGER;",
+
+        # order.py models
+        "ALTER TABLE auction_bids ALTER COLUMN bidder_id TYPE INTEGER USING bidder_id::INTEGER;",
+        "ALTER TABLE auctions ALTER COLUMN winner_id TYPE INTEGER USING winner_id::INTEGER;",
+        "ALTER TABLE auctions ALTER COLUMN seller_id TYPE INTEGER USING seller_id::INTEGER;",
+        "ALTER TABLE orders ALTER COLUMN resolved_by_admin_id TYPE INTEGER USING resolved_by_admin_id::INTEGER;",
+        "ALTER TABLE orders ALTER COLUMN seller_id TYPE INTEGER USING seller_id::INTEGER;",
+        "ALTER TABLE orders ALTER COLUMN buyer_id TYPE INTEGER USING buyer_id::INTEGER;",
+
+        # user.py models
+        "ALTER TABLE fund_locks ALTER COLUMN user_id TYPE INTEGER USING user_id::INTEGER;",
+        "ALTER TABLE transactions ALTER COLUMN processed_by_admin_id TYPE INTEGER USING processed_by_admin_id::INTEGER;",
+        "ALTER TABLE transactions ALTER COLUMN user_id TYPE INTEGER USING user_id::INTEGER;",
+        "ALTER TABLE wallets ALTER COLUMN user_id TYPE INTEGER USING user_id::INTEGER;",
+        "ALTER TABLE seller_profiles ALTER COLUMN verified_by_admin_id TYPE INTEGER USING verified_by_admin_id::INTEGER;",
+        "ALTER TABLE seller_profiles ALTER COLUMN user_id TYPE INTEGER USING user_id::INTEGER;",
+    ]
+
+    for stmt in statements:
+        op.execute(stmt)
+
+    # החזרת ה-sequence ל-INT
+    op.execute("ALTER SEQUENCE users_id_seq AS INTEGER;")
+
+    # החזרת ה-PK לטיפוס INTEGER
+    op.execute(
+        """
+        ALTER TABLE users 
+        ALTER COLUMN id 
+        TYPE INTEGER 
+        USING id::INTEGER;
+        """
+    )
+

--- a/app/models/coupon.py
+++ b/app/models/coupon.py
@@ -9,7 +9,7 @@ from typing import Optional
 from decimal import Decimal
 
 from sqlalchemy import (
-    String, Integer, Boolean, DateTime, Numeric, Text,
+    String, Integer, BigInteger, Boolean, DateTime, Numeric, Text,
     ForeignKey, Index, CheckConstraint, UniqueConstraint
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -124,7 +124,7 @@ class Coupon(Base):
     )
 
     # === שדות חובה (ללא ברירת מחדל/nullable ב-init של dataclass) ===
-    seller_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    seller_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"))
     # לפי הדרישה: להציב expires_at מוקדם
     expires_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
@@ -282,7 +282,7 @@ class UserFavorite(Base):
     __tablename__ = "user_favorites"
     
     id: Mapped[int] = mapped_column(Integer, primary_key=True, init=False)
-    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"))
     coupon_id: Mapped[str] = mapped_column(ForeignKey("coupons.id", ondelete="CASCADE"))
     
     # Tracking - שדות חובה לפני שדות עם ברירת מחדל
@@ -344,8 +344,8 @@ class CouponRating(Base):
     
     # Foreign Keys (שדות חובה)
     order_id: Mapped[str] = mapped_column(ForeignKey("orders.id", ondelete="CASCADE"))
-    buyer_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
-    seller_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    buyer_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"))
+    seller_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"))
     coupon_id: Mapped[str] = mapped_column(ForeignKey("coupons.id", ondelete="CASCADE"))
     
     # Rating Details (חובה/nullable ללא ברירות מחדל)

--- a/app/models/order.py
+++ b/app/models/order.py
@@ -9,7 +9,7 @@ from typing import Optional
 from decimal import Decimal
 
 from sqlalchemy import (
-    String, Integer, Boolean, DateTime, Numeric, Text,
+    String, Integer, BigInteger, Boolean, DateTime, Numeric, Text,
     ForeignKey, Index, CheckConstraint, UniqueConstraint
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -65,8 +65,8 @@ class Order(Base):
     )
     
     # Participants
-    buyer_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
-    seller_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    buyer_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"))
+    seller_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"))
     coupon_id: Mapped[str] = mapped_column(ForeignKey("coupons.id", ondelete="CASCADE"))
     
     # Order Details (ללא ברירות מחדל קודם)
@@ -111,7 +111,7 @@ class Order(Base):
     )
     dispute_description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     resolved_by_admin_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("users.id"), nullable=True
+        BigInteger, ForeignKey("users.id"), nullable=True
     )
     resolved_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
@@ -218,7 +218,7 @@ class Auction(Base):
     )
     
     # Basic Info
-    seller_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    seller_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"))
     coupon_id: Mapped[str] = mapped_column(ForeignKey("coupons.id", ondelete="CASCADE"))
     
     # Auction Settings
@@ -237,7 +237,7 @@ class Auction(Base):
     
     # Winner Info (ללא ברירת מחדל)
     winner_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("users.id"), nullable=True
+        BigInteger, ForeignKey("users.id"), nullable=True
     )
     winning_bid_id: Mapped[Optional[str]] = mapped_column(
         ForeignKey("auction_bids.id"), nullable=True
@@ -331,7 +331,7 @@ class AuctionBid(Base):
     
     # Foreign Keys (ללא ברירות מחדל קודם)
     auction_id: Mapped[str] = mapped_column(ForeignKey("auctions.id", ondelete="CASCADE"))
-    bidder_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    bidder_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"))
     fund_lock_id: Mapped[Optional[str]] = mapped_column(ForeignKey("fund_locks.id"), nullable=True)
     
     # Bid Details

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -60,7 +60,7 @@ class User(Base):
     __tablename__ = "users"
     
     # Basic Info
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, index=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, index=True, init=False)
     telegram_user_id: Mapped[int] = mapped_column(BigInteger, unique=True, index=True)
     username: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     first_name: Mapped[str] = mapped_column(String(100))

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -60,7 +60,7 @@ class User(Base):
     __tablename__ = "users"
     
     # Basic Info
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, init=False)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, index=True)
     telegram_user_id: Mapped[int] = mapped_column(BigInteger, unique=True, index=True)
     username: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     first_name: Mapped[str] = mapped_column(String(100))
@@ -133,7 +133,7 @@ class SellerProfile(Base):
     __tablename__ = "seller_profiles"
     
     id: Mapped[int] = mapped_column(Integer, primary_key=True, init=False)
-    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"))
     
     # Business Info
     business_name: Mapped[str] = mapped_column(String(200))
@@ -142,7 +142,7 @@ class SellerProfile(Base):
     
     # Non-default verification fields
     verified_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
-    verified_by_admin_id: Mapped[Optional[int]] = mapped_column(ForeignKey("users.id"), nullable=True)
+    verified_by_admin_id: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("users.id"), nullable=True)
     
     # Non-default stats field (צריך להופיע לפני שדות עם ברירת מחדל)
     average_rating: Mapped[Optional[Decimal]] = mapped_column(Numeric(3, 2), nullable=True)
@@ -214,7 +214,7 @@ class Wallet(Base):
     __tablename__ = "wallets"
     
     id: Mapped[int] = mapped_column(Integer, primary_key=True, init=False)
-    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), unique=True)
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"), unique=True)
 
     # === Relationships === (ללא ברירת מחדל – לפני שדות עם ברירת מחדל)
     user: Mapped["User"] = relationship("User", back_populates="wallet")
@@ -280,7 +280,7 @@ class Transaction(Base):
     )
     
     # Foreign Keys
-    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"))
     wallet_id: Mapped[int] = mapped_column(ForeignKey("wallets.id", ondelete="CASCADE"))
     
     # Transaction Details
@@ -298,7 +298,7 @@ class Transaction(Base):
 
     # Non-default optional fields (לפני ברירות מחדל)
     extra_metadata: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # JSON נוסף
-    processed_by_admin_id: Mapped[Optional[int]] = mapped_column(ForeignKey("users.id"), nullable=True)
+    processed_by_admin_id: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("users.id"), nullable=True)
 
     # === Relationships === (ללא ברירות מחדל – לפני שדות עם ברירת מחדל)
     user: Mapped["User"] = relationship(
@@ -351,7 +351,7 @@ class FundLock(Base):
     )
     
     # Foreign Keys
-    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"))
     wallet_id: Mapped[int] = mapped_column(ForeignKey("wallets.id", ondelete="CASCADE"))
     
     # Lock Details

--- a/tests/test_user_creation_minimal.py
+++ b/tests/test_user_creation_minimal.py
@@ -5,6 +5,7 @@ from app.models.user import User, UserRole
 
 def test_create_user_minimal_buyer() -> None:
     user = User(
+        id=1,
         telegram_user_id=111111111,
         username="testbuyer",
         first_name="Test",
@@ -26,6 +27,7 @@ def test_create_user_minimal_buyer() -> None:
 
 def test_create_user_minimal_seller() -> None:
     user = User(
+        id=2,
         telegram_user_id=222222222,
         username="testseller",
         first_name="Test",

--- a/tests/test_user_creation_minimal.py
+++ b/tests/test_user_creation_minimal.py
@@ -5,7 +5,6 @@ from app.models.user import User, UserRole
 
 def test_create_user_minimal_buyer() -> None:
     user = User(
-        id=1,
         telegram_user_id=111111111,
         username="testbuyer",
         first_name="Test",
@@ -27,7 +26,6 @@ def test_create_user_minimal_buyer() -> None:
 
 def test_create_user_minimal_seller() -> None:
     user = User(
-        id=2,
         telegram_user_id=222222222,
         username="testseller",
         first_name="Test",


### PR DESCRIPTION
Change `users.id` and all related foreign keys to `BIGINT` to prevent `NumericValueOutOfRangeError` for large user IDs.

The `asyncpg.exceptions.NumericValueOutOfRangeError` occurred when creating new users (buyers and sellers) because the `id` column in the `users` table was defined as `INTEGER`, which has a smaller maximum value than `BIGINT`. This change ensures that user IDs can accommodate larger values without overflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba30a228-67fa-424f-be3f-8062cbf82490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ba30a228-67fa-424f-be3f-8062cbf82490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

