### PR TITLE
Fix wallet and seller profile creation type errors

### DIFF
--- a/app/bot/handlers/main.py
+++ b/app/bot/handlers/main.py
@@ -216,8 +216,13 @@ class MainHandlers:
                 
                 # יצירת פרופיל מוכר
                 seller_profile = SellerProfile(
-                    user_id=new_user.id,
+                    user=new_user,
                     business_name=f"עסק של {new_user.first_name}",  # זמני
+                    description="",
+                    verification_documents=[],
+                    verified_at=None,
+                    verified_by_admin_id=None,
+                    average_rating=Decimal('0.00'),
                     verification_status=VerificationStatus.UNVERIFIED,
                     daily_quota=10  # ברירת מחדל למוכר לא מאומת
                 )

--- a/app/services/wallet_service.py
+++ b/app/services/wallet_service.py
@@ -47,8 +47,12 @@ class WalletService:
     
     async def create_wallet(self, user_id: int) -> Wallet:
         """יצירת ארנק חדש"""
+        # טעינת אובייקט המשתמש כדי לשייך יחסים ב-init
+        user = await self.session.get(User, user_id)
         wallet = Wallet(
-            user_id=user_id,
+            user=user,
+            transactions=[],
+            fund_locks=[],
             total_balance=Decimal('0.00'),
             locked_balance=Decimal('0.00')
         )


### PR DESCRIPTION
Fix `TypeError` during `Wallet` and `SellerProfile` creation by adjusting model defaults and instantiation parameters.

The `TypeError` occurred because certain fields were expected during object instantiation but not provided. This PR sets appropriate `default` or `nullable=True` values in the models and ensures that relationships and optional fields are explicitly passed with default empty/None values during object creation, preventing the error. The `verification_documents` field was also converted to JSONB for better handling of list data.

---
<a href="https://cursor.com/background-agent?bcId=bc-e21a2f9e-7ba7-4211-86ba-c34234ac6b62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e21a2f9e-7ba7-4211-86ba-c34234ac6b62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

