### PR TITLE
Fix seller profile user id integrity

### DIFF
--- a/app/bot/handlers/main.py
+++ b/app/bot/handlers/main.py
@@ -217,14 +217,18 @@ class MainHandlers:
                 # יצירת פרופיל מוכר (אחרי שה-user נשמר וקיבל id)
                 seller_profile = SellerProfile(
                     user_id=new_user.id,
-                    business_name=f"עסק של {new_user.first_name}",  # זמני
+                    business_name="",
                     description="",
                     verification_documents=[],
                     verified_at=None,
                     verified_by_admin_id=None,
                     average_rating=Decimal('0.00'),
+                    is_verified=False,
                     verification_status=VerificationStatus.UNVERIFIED,
-                    daily_quota=10  # ברירת מחדל למוכר לא מאומת
+                    daily_quota=10,
+                    daily_count=0,
+                    total_sales=0,
+                    total_ratings=0
                 )
                 
                 session.add(seller_profile)


### PR DESCRIPTION
Fix `IntegrityError` for `SellerProfile` creation by ensuring `user_id` is available and setting complete default values.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c768dd4-4133-4705-ab18-73437cabb61b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2c768dd4-4133-4705-ab18-73437cabb61b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

