### PR TITLE
Add user relationships to wallet and seller profile models

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -71,13 +71,17 @@ class User(Base):
     wallets: Mapped[list["Wallet"]] = relationship(
         "Wallet",
         back_populates="user",
-        cascade="all, delete-orphan"
+        cascade="all, delete-orphan",
+        default_factory=list
     )
-    seller_profile: Mapped["SellerProfile"] = relationship(
+    seller_profile: Mapped[Optional["SellerProfile"]] = relationship(
         "SellerProfile",
         back_populates="user",
         uselist=False,
-        cascade="all, delete-orphan"
+        cascade="all, delete-orphan",
+        foreign_keys=lambda: [SellerProfile.user_id],
+        primaryjoin=lambda: User.id == SellerProfile.user_id,
+        default=None
     )
     
     # Contact Info (עבור מוכרים) - שדות אופציונליים
@@ -141,7 +145,12 @@ class SellerProfile(Base):
     business_name: Mapped[str] = mapped_column(String(200))
 
     # === Relationships (non-default first) ===
-    user: Mapped["User"] = relationship("User", back_populates="seller_profile")
+    user: Mapped["User"] = relationship(
+        "User",
+        back_populates="seller_profile",
+        foreign_keys=lambda: [SellerProfile.user_id],
+        primaryjoin=lambda: User.id == SellerProfile.user_id
+    )
 
     # Fields with defaults
     description: Mapped[str] = mapped_column(Text, nullable=True, default="")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -123,6 +123,7 @@ class User(Base):
         Index("idx_users_role", "role"),
         Index("idx_users_active", "is_active"),
         Index("idx_users_created", "created_at"),
+        {"extend_existing": True},
     )
     
     def __repr__(self) -> str:
@@ -138,6 +139,11 @@ class SellerProfile(Base):
     
     # Business Info
     business_name: Mapped[str] = mapped_column(String(200))
+
+    # === Relationships (non-default first) ===
+    user: Mapped["User"] = relationship("User", back_populates="seller_profile")
+
+    # Fields with defaults
     description: Mapped[str] = mapped_column(Text, nullable=True, default="")
     verification_documents: Mapped[list] = mapped_column(MutableList.as_mutable(JSONB), nullable=False, default_factory=list)
     
@@ -148,8 +154,7 @@ class SellerProfile(Base):
     # Non-default stats field (צריך להופיע לפני שדות עם ברירת מחדל)
     average_rating: Mapped[Decimal] = mapped_column(Numeric(3, 2), nullable=False, default=Decimal('0.00'))
     
-    # === Relationships === (ללא ברירות מחדל – לפני שדות עם ברירת מחדל)
-    user: Mapped["User"] = relationship("User", back_populates="seller_profile")
+    
 
     # Defaulted fields (לבסוף)
     is_verified: Mapped[bool] = mapped_column(Boolean, default=False)

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -92,18 +92,17 @@ class User(Base):
         init=False
     )
     
-    # === Relationships === (עם ברירות מחדל כדי שלא יהיו חובה ב-__init__)
-    wallet: Mapped[Optional["Wallet"]] = relationship(
-        "Wallet", back_populates="user", uselist=False, cascade="all, delete-orphan", default=None
+    # === Relationships ===
+    wallets: Mapped[list["Wallet"]] = relationship(
+        "Wallet",
+        back_populates="user",
+        cascade="all, delete-orphan"
     )
-    seller_profile: Mapped[Optional["SellerProfile"]] = relationship(
+    seller_profile: Mapped["SellerProfile"] = relationship(
         "SellerProfile",
         back_populates="user",
         uselist=False,
-        cascade="all, delete-orphan",
-        foreign_keys=lambda: [SellerProfile.user_id],
-        primaryjoin=lambda: User.id == SellerProfile.user_id,
-        default=None
+        cascade="all, delete-orphan"
     )
     transactions: Mapped[list["Transaction"]] = relationship(
         "Transaction",
@@ -134,7 +133,7 @@ class SellerProfile(Base):
     __tablename__ = "seller_profiles"
     
     id: Mapped[int] = mapped_column(Integer, primary_key=True, init=False)
-    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"))
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
     
     # Business Info
     business_name: Mapped[str] = mapped_column(String(200))
@@ -149,13 +148,7 @@ class SellerProfile(Base):
     average_rating: Mapped[Decimal] = mapped_column(Numeric(3, 2), nullable=False, default=Decimal('0.00'))
     
     # === Relationships === (ללא ברירות מחדל – לפני שדות עם ברירת מחדל)
-    user: Mapped["User"] = relationship(
-        "User",
-        back_populates="seller_profile",
-        foreign_keys=lambda: [SellerProfile.user_id],
-        primaryjoin=lambda: User.id == SellerProfile.user_id,
-        default=None
-    )
+    user: Mapped["User"] = relationship("User", back_populates="seller_profile")
 
     # Defaulted fields (לבסוף)
     is_verified: Mapped[bool] = mapped_column(Boolean, default=False)
@@ -216,10 +209,10 @@ class Wallet(Base):
     __tablename__ = "wallets"
     
     id: Mapped[int] = mapped_column(Integer, primary_key=True, init=False)
-    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"), unique=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
 
     # === Relationships === (ללא ברירת מחדל – לפני שדות עם ברירת מחדל)
-    user: Mapped["User"] = relationship("User", back_populates="wallet", default=None)
+    user: Mapped["User"] = relationship("User", back_populates="wallets")
     transactions: Mapped[list["Transaction"]] = relationship(
         "Transaction", back_populates="wallet", cascade="all, delete-orphan", default_factory=list
     )

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -67,6 +67,19 @@ class User(Base):
     first_name: Mapped[str] = mapped_column(String(100))
     last_name: Mapped[Optional[str]] = mapped_column(String(100), nullable=True)
     
+    # === Relationships (non-default) ===
+    wallets: Mapped[list["Wallet"]] = relationship(
+        "Wallet",
+        back_populates="user",
+        cascade="all, delete-orphan"
+    )
+    seller_profile: Mapped["SellerProfile"] = relationship(
+        "SellerProfile",
+        back_populates="user",
+        uselist=False,
+        cascade="all, delete-orphan"
+    )
+    
     # Contact Info (עבור מוכרים) - שדות אופציונליים
     phone: Mapped[Optional[str]] = mapped_column(String(20), nullable=True, default=None)
     email: Mapped[Optional[str]] = mapped_column(String(200), nullable=True, default=None)
@@ -92,18 +105,6 @@ class User(Base):
         init=False
     )
     
-    # === Relationships ===
-    wallets: Mapped[list["Wallet"]] = relationship(
-        "Wallet",
-        back_populates="user",
-        cascade="all, delete-orphan"
-    )
-    seller_profile: Mapped["SellerProfile"] = relationship(
-        "SellerProfile",
-        back_populates="user",
-        uselist=False,
-        cascade="all, delete-orphan"
-    )
     transactions: Mapped[list["Transaction"]] = relationship(
         "Transaction",
         back_populates="user",

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -139,7 +139,7 @@ class SellerProfile(Base):
     __tablename__ = "seller_profiles"
     
     id: Mapped[int] = mapped_column(Integer, primary_key=True, init=False)
-    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"), unique=True)
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"), unique=True, init=False)
     
     # Business Info
     business_name: Mapped[str] = mapped_column(String(200))
@@ -224,10 +224,10 @@ class Wallet(Base):
     __tablename__ = "wallets"
     
     id: Mapped[int] = mapped_column(Integer, primary_key=True, init=False)
-    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"), unique=True, init=False)
 
     # === Relationships === (ללא ברירת מחדל – לפני שדות עם ברירת מחדל)
-    user: Mapped["User"] = relationship("User", back_populates="wallets")
+    user: Mapped["User"] = relationship("User", back_populates="wallets", default=None)
     transactions: Mapped[list["Transaction"]] = relationship(
         "Transaction", back_populates="wallet", cascade="all, delete-orphan", default_factory=list
     )

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -134,7 +134,7 @@ class SellerProfile(Base):
     __tablename__ = "seller_profiles"
     
     id: Mapped[int] = mapped_column(Integer, primary_key=True, init=False)
-    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), nullable=False)
+    user_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="CASCADE"), unique=True)
     
     # Business Info
     business_name: Mapped[str] = mapped_column(String(200))

--- a/tests/test_user_creation_minimal.py
+++ b/tests/test_user_creation_minimal.py
@@ -20,7 +20,7 @@ def test_create_user_minimal_buyer() -> None:
     assert user.phone is None
     assert user.email is None
     assert user.last_activity_at is not None
-    assert user.wallet is None
+    assert len(user.wallets) == 0
     assert len(user.transactions) == 0
     assert len(user.fund_locks) == 0
 
@@ -36,7 +36,7 @@ def test_create_user_minimal_seller() -> None:
 
     assert user.telegram_user_id == 222222222
     assert user.role == UserRole.SELLER
-    assert user.wallet is None
+    assert len(user.wallets) == 0
     assert len(user.transactions) == 0
     assert len(user.fund_locks) == 0
 

--- a/tests/test_user_creation_minimal.py
+++ b/tests/test_user_creation_minimal.py
@@ -66,7 +66,7 @@ async def test_wallet_creation(async_session):
     await async_session.flush()
 
     assert user.id is not None
-    wallet = Wallet(user=user, user_id=user.id, transactions=[], fund_locks=[])
+    wallet = Wallet(user=user, transactions=[], fund_locks=[])
     async_session.add(wallet)
     await async_session.flush()
     assert wallet.id is not None
@@ -87,7 +87,6 @@ async def test_seller_profile_creation(async_session):
     assert user.id is not None
     seller = SellerProfile(
         user=user,
-        user_id=user.id,
         business_name="Test Biz",
         description="",
         verification_documents=[],

--- a/tests/test_user_relations.py
+++ b/tests/test_user_relations.py
@@ -5,7 +5,12 @@ from app.models.user import User, Wallet, SellerProfile
 @pytest.mark.asyncio
 async def test_user_wallet_and_seller(async_session):
     # יצירת משתמש חדש
-    user = User(telegram_user_id=1234567890, username="testuser")
+    user = User(
+        telegram_user_id=1234567890,
+        username="testuser",
+        first_name="Test",
+        last_name="User",
+    )
     async_session.add(user)
     await async_session.flush()
     assert user.id is not None

--- a/tests/test_user_relations.py
+++ b/tests/test_user_relations.py
@@ -16,12 +16,12 @@ async def test_user_wallet_and_seller(async_session):
     await async_session.flush()
     assert user.id is not None
 
-    # יצירת ארנק דרך user_id (נדרש ע"י הדאטהקלאס)
-    wallet = Wallet(user_id=user.id, transactions=[], fund_locks=[])
+    # יצירת ארנק דרך relationship
+    wallet = Wallet(user=user, transactions=[], fund_locks=[])
     async_session.add(wallet)
 
-    # יצירת פרופיל מוכר - שומר גם user וגם user_id
-    seller = SellerProfile(user=user, user_id=user.id, business_name="Test Biz")
+    # יצירת פרופיל מוכר דרך relationship
+    seller = SellerProfile(user=user, business_name="Test Biz")
     async_session.add(seller)
 
     # flush למסד

--- a/tests/test_user_relations.py
+++ b/tests/test_user_relations.py
@@ -1,0 +1,29 @@
+import pytest
+from app.models.user import User, Wallet, SellerProfile
+
+
+@pytest.mark.asyncio
+async def test_user_wallet_and_seller(async_session):
+    # יצירת משתמש חדש
+    user = User(telegram_user_id=1234567890, username="testuser")
+    async_session.add(user)
+    await async_session.flush()
+    assert user.id is not None
+
+    # יצירת ארנק דרך relationship
+    wallet = Wallet(user=user, transactions=[], fund_locks=[])
+    async_session.add(wallet)
+
+    # יצירת פרופיל מוכר דרך relationship
+    seller = SellerProfile(user=user, business_name="Test Biz")
+    async_session.add(seller)
+
+    # flush למסד
+    await async_session.flush()
+
+    # בדיקות
+    assert wallet.id is not None
+    assert wallet.user_id == user.id
+    assert seller.id is not None
+    assert seller.user_id == user.id
+

--- a/tests/test_user_relations.py
+++ b/tests/test_user_relations.py
@@ -16,12 +16,12 @@ async def test_user_wallet_and_seller(async_session):
     await async_session.flush()
     assert user.id is not None
 
-    # יצירת ארנק דרך relationship
-    wallet = Wallet(user=user, transactions=[], fund_locks=[])
+    # יצירת ארנק דרך user_id (נדרש ע"י הדאטהקלאס)
+    wallet = Wallet(user_id=user.id, transactions=[], fund_locks=[])
     async_session.add(wallet)
 
-    # יצירת פרופיל מוכר דרך relationship
-    seller = SellerProfile(user=user, business_name="Test Biz")
+    # יצירת פרופיל מוכר - שומר גם user וגם user_id
+    seller = SellerProfile(user=user, user_id=user.id, business_name="Test Biz")
     async_session.add(seller)
 
     # flush למסד

--- a/tests/test_user_relations.py
+++ b/tests/test_user_relations.py
@@ -1,4 +1,5 @@
 import pytest
+import random
 from app.models.user import User, Wallet, SellerProfile
 
 
@@ -6,7 +7,7 @@ from app.models.user import User, Wallet, SellerProfile
 async def test_user_wallet_and_seller(async_session):
     # יצירת משתמש חדש
     user = User(
-        telegram_user_id=1234567890,
+        telegram_user_id=random.randint(1_000_000_000, 10_000_000_000),
         username="testuser",
         first_name="Test",
         last_name="User",


### PR DESCRIPTION
Add explicit SQLAlchemy relationships between `User`, `Wallet`, and `SellerProfile` models to enable object-based entity creation and automatic `user_id` population.

---
<a href="https://cursor.com/background-agent?bcId=bc-1cb429b7-e187-41ae-b491-69eb26baa45a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1cb429b7-e187-41ae-b491-69eb26baa45a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

